### PR TITLE
Add pyproject.toml for Custom Node Registry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[project]
+name = "comfyui-i2vgen-xl"
+description = "This is an implementation of [a/i2vgen-xl](https://github.com/ali-vilab/i2vgen-xl)"
+version = "1.0.0"
+license = "LICENSE"
+dependencies = ["easydict>=1.10", "tokenizers>=0.12.1", "numpy>=1.19.2", "ftfy>=6.1.1", "transformers>=4.18.0", "imageio>=2.15.0", "fairscale>=0.4.6", "ipdb", "open-clip-torch>=2.0.2", "xformers>=0.0.13", "chardet>=5.1.0", "torchdiffeq>=0.2.3", "opencv-python>=4.4.0.46", "opencv-python-headless>=4.7.0.68", "torchsde>=0.2.6", "simplejson>=3.18.4", "scikit-learn", "scikit-image", "rotary-embedding-torch>=0.2.1", "pynvml>=11.5.0", "pytorch-lightning>=1.4.2", "torchmetrics>=0.6.0", "imageio-ffmpeg"]
+
+[project.urls]
+Repository = "https://github.com/chaojie/ComfyUI-I2VGEN-XL"
+#  Used by Comfy Registry https://comfyregistry.org
+
+[tool.comfy]
+PublisherId = ""
+DisplayName = "ComfyUI-I2VGEN-XL"
+Icon = ""


### PR DESCRIPTION
We are working with dr.lt.data and comfyanon to build a global registry for custom nodes (similar to PyPI). Eventually, the registry will be used as a backend for the UI-manager. All nodes go through a verification process before being published to users.

The main benefits are that authors can
- publish nodes by version and users can safely update nodes knowing ahead of time if their workflows will break or not
- automate testing against new commits in the comfy repo and existing workflows through our CI/CD dashboard

Action Required:

- [ ] Go to the [registry](https://registry.comfy.org). Login and create a publisher id (everything after the `@` sign on your registry profile). 
- [ ] Add the publisher id into the pyproject.toml file.
- [ ] Merge the separate Github Actions PR, then merge this PR.

If you want to publish the node manually, [install the cli](https://docs.comfy.org/comfy-cli/getting-started#install-cli) by running `pip install comfy-cli`, then run `comfy node publish`

Check out our [docs](https://docs.comfy.org/registry/overview#introduction) if you want to know more about the registry. Otherwise, feel free to message me on discord at haohao_81202 or join our [server](https://discord.com/invite/comfyorg) if you have any questions!